### PR TITLE
Fixed `swap_right` and `swap_left`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prop"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 edition = "2018"
 description = "Propositional logic with types in Rust"

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -118,13 +118,13 @@ pub fn assoc<A: DProp, B: DProp, C: DProp>(f: Eq<Eq<A, B>, C>) -> Eq<A, Eq<B, C>
 }
 
 /// `a = (b = c)  =>  a = (c = b)`.
-pub fn swap_right<A: DProp, B: Prop, C: Prop>((f0, f1): Eq<A, Eq<B, C>>) -> Eq<A, Eq<C, B>> {
+pub fn swap_right<A: Prop, B: Prop, C: Prop>((f0, f1): Eq<A, Eq<B, C>>) -> Eq<A, Eq<C, B>> {
     (Rc::new(move |x| {let (g0, g1) = f0(x); (g1, g0)}),
      Rc::new(move |(g1, g0)| f1((g0, g1))))
 }
 
 /// `(a = b) = c  =>  (b = a) = c`.
-pub fn swap_left<A: DProp, B: Prop, C: DProp>(f: Eq<Eq<A, B>, C>) -> Eq<Eq<B, A>, C> {
+pub fn swap_left<A: Prop, B: Prop, C: Prop>(f: Eq<Eq<A, B>, C>) -> Eq<Eq<B, A>, C> {
     commute(swap_right(commute(f)))
 }
 


### PR DESCRIPTION
`DProp` is not needed.

- Bumped to 0.9.2