### PR TITLE
Removed `PureSeshatism`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,3 @@ name = "prop"
 [features]
 default = []
 pure_platonism = []
-pure_seshatism = []


### PR DESCRIPTION
See https://github.com/advancedresearch/prop/issues/191

- Removed feature flag
- Removed docs
- Removed `quality::asume_pure_seshatism`
- Removed `quality::sesh_eq_neq_seshat`
- Removed feature requirements on methods that used `PureSeshatism`
- Removed "(Moment Witness)" from the docs since it might be misleading