### PR TITLE
Use `eqq` instead of `eq_q` for `EqQ`

### DIFF
--- a/src/quality.rs
+++ b/src/quality.rs
@@ -186,15 +186,15 @@ pub fn neq_to_sesh<A: Prop, B: Prop>(neq: Not<Eq<A, B>>) -> Not<Q<A, B>> {
     Rc::new(move |q_ab| neq(to_eq(q_ab)))
 }
 
-/// Convert inquality to inequality `¬(a ~~ b) ⋀ eq_q(a, b) => ¬(a == b)`.
-pub fn sesh_to_neq<A: Prop, B: Prop>(sesh: Not<Q<A, B>>, eq_q_ab: EqQ<A, B>) -> Not<Eq<A, B>> {
-    imply::modus_tollens(eq_q_ab)(sesh)
+/// Convert inquality to inequality `¬(a ~~ b) ⋀ eqq(a, b) => ¬(a == b)`.
+pub fn sesh_to_neq<A: Prop, B: Prop>(sesh: Not<Q<A, B>>, eqq_ab: EqQ<A, B>) -> Not<Eq<A, B>> {
+    imply::modus_tollens(eqq_ab)(sesh)
 }
 
-/// `eq_q(a, b)  =>  ¬(a ~~ b) == ¬(a == b)`.
-pub fn sesh_eq_neq<A: Prop, B: Prop>(eq_q_ab: EqQ<A, B>) -> Eq<Not<Q<A, B>>, Not<Eq<A, B>>> {
+/// `eqq(a, b)  =>  ¬(a ~~ b) == ¬(a == b)`.
+pub fn sesh_eq_neq<A: Prop, B: Prop>(eqq_ab: EqQ<A, B>) -> Eq<Not<Q<A, B>>, Not<Eq<A, B>>> {
     (
-        Rc::new(move |nq_ab| sesh_to_neq(nq_ab, eq_q_ab.clone())),
+        Rc::new(move |nq_ab| sesh_to_neq(nq_ab, eqq_ab.clone())),
         Rc::new(move |neq_ab| neq_to_sesh(neq_ab)),
     )
 }

--- a/src/univalence.rs
+++ b/src/univalence.rs
@@ -41,12 +41,12 @@ pub type Univ<A, B> = Q<Eq<A, B>, Q<A, B>>;
 pub type EqUniv<A, B> = Imply<Eq<A, B>, Univ<A, B>>;
 
 /// `((a == b) => ((a == b) ~~ (a ~~ b))) => ((a == b) => (a ~~ b))`.
-pub fn eq_univ_to_eq_q<A: Prop, B: Prop>(p: EqUniv<A, B>) -> EqQ<A, B> {
+pub fn eq_univ_to_eqq<A: Prop, B: Prop>(p: EqUniv<A, B>) -> EqQ<A, B> {
     Rc::new(move |eq| quality::to_eq(p(eq.clone())).0(eq))
 }
 
 /// `((a == b) => (a ~~ b)) => ((a == b) ~~ (a ~~ b))`.
-pub fn eq_q_to_univ<A: Prop, B: Prop>(p: EqQ<A, B>) -> Univ<A, B> {
+pub fn eqq_to_univ<A: Prop, B: Prop>(p: EqQ<A, B>) -> Univ<A, B> {
     eq_lift((
         Rc::new(move |eq| p(eq)),
         Rc::new(move |q| quality::to_eq(q))
@@ -54,8 +54,13 @@ pub fn eq_q_to_univ<A: Prop, B: Prop>(p: EqQ<A, B>) -> Univ<A, B> {
 }
 
 /// `((a == b) ~~ (a ~~ b)) => ((a == b) => (a ~~ b))`.
-pub fn univ_to_eq_q<A: Prop, B: Prop>(univ: Univ<A, B>) -> EqQ<A, B> {
-    eq_univ_to_eq_q(univ.map_any())
+pub fn univ_to_eqq<A: Prop, B: Prop>(univ: Univ<A, B>) -> EqQ<A, B> {
+    eq_univ_to_eqq(univ.map_any())
+}
+
+/// Lift `(a == b) == (a ~~ b)` to `(a == b) ~~ (a ~~ b)`.
+pub fn eq_lift<A: Prop, B: Prop>(eq_eq_q: Eq<Eq<A, B>, Q<A, B>>) -> Univ<A, B> {
+    Q(eq_eq_q)
 }
 
 /// `((a => b) => (a ~~ b)) => ((a == b) ~~ (a ~~ b))`.
@@ -68,7 +73,7 @@ pub fn hom_to_univ<A: Prop, B: Prop>(hom: Hom<A, B>) -> Univ<A, B> {
 
 /// `((a == b) => (a ~~ b)) => ((a == b) ~~ (a ~~ b))`.
 pub fn hom_eq_q<A: Prop, B: Prop>() -> Hom<Eq<A, B>, Q<A, B>> {
-    Rc::new(move |x| eq_q_to_univ(x))
+    Rc::new(move |x| eqq_to_univ(x))
 }
 
 /// `((a == b) == (a ~~ b)) ~~ ((a == b) ~~ (a ~~ b))`.
@@ -77,13 +82,8 @@ pub fn univ_eq_q<A: Prop, B: Prop>() -> Univ<Eq<A, B>, Q<A, B>> {
 }
 
 /// `((a == b) == (a ~~ b)) => ((a == b) ~~ (a ~~ b))`.
-pub fn eq_q_eq_q<A: Prop, B: Prop>() -> EqQ<Eq<A, B>, Q<A, B>> {
-    univ_to_eq_q(univ_eq_q())
-}
-
-/// Lift `(a == b) == (a ~~ b)` to `(a == b) ~~ (a ~~ b)`.
-pub fn eq_lift<A: Prop, B: Prop>(eq_eq_q: Eq<Eq<A, B>, Q<A, B>>) -> Univ<A, B> {
-    Q(eq_eq_q)
+pub fn eqq_eq_q<A: Prop, B: Prop>() -> EqQ<Eq<A, B>, Q<A, B>> {
+    univ_to_eqq(univ_eq_q())
 }
 
 /// Higher quality univalence.


### PR DESCRIPTION
Closes https://github.com/advancedresearch/prop/issues/199

- Renamed to `eq_univ_to_eqq`
- Renamed to `eqq_to_univ`
- Renamed to `univ_to_eqq`
- Renamed to `eqq_eq_q`
- Moved `eq_lift` in front of other functions that uses it