### PR TITLE
Removed `POrdProof::by_imply_left`

### DIFF
--- a/src/fun.rs
+++ b/src/fun.rs
@@ -301,20 +301,6 @@ pub fn app_fun_swap_ty<F: Prop, X: Prop, Y: Prop, A: Prop, B: Prop>(
     {Rc::new(move |x| app_fun_ty(app_rev_fun_ty(x), ty_b.clone()))}
     hooo::hooo_imply(f)(hooo::pow_lift(x))
 }
-/// `(f(a) : y)^true == (f(b) : y)^true`.
-pub fn app_fun_swap_tauto_ty<F: Prop, Y: Prop, A: Prop, B: Prop>() ->
-    Eq<Tauto<Ty<App<F, A>, Y>>, Tauto<Ty<App<F, B>, Y>>>
-{
-    use hooo::tr;
-    use path_semantics::{ty_rev_true, ty_inhabit};
-
-    let x: Tauto<True> = hooo::pow_refl;
-    let ty_a = x.trans(ty_rev_true).trans(ty_inhabit);
-    let ty_b = x.trans(ty_rev_true).trans(ty_inhabit);
-    let (y1, y2) = (Rc::new(app_fun_swap_ty), Rc::new(app_fun_swap_ty));
-    (Rc::new(move |x| ty_b.trans(y1(tr().trans(x)))),
-     Rc::new(move |x| ty_a.trans(y2(tr().trans(x)))))
-}
 
 /// Imaginary inverse.
 #[derive(Copy, Clone)]

--- a/src/hooo.rs
+++ b/src/hooo.rs
@@ -678,11 +678,6 @@ pub fn pow_ty<A: Prop, B: Prop, X: Prop, Y: Prop>(
     ty_pow_ba: Ty<Pow<B, A>, Pow<Y, X>>
 ) -> Ty<B, Y> {hooo_rev_ty(ty_pow_ba)(ty_a)}
 
-/// `(a : b)  =>  (a^true : b)`.
-pub fn tauto_ty<A: Prop, B: Prop>((x, y): Ty<A, B>) -> Ty<Tauto<A>, B> {
-    (imply::in_left(x, |y: Tauto<A>| y(True)), y.by_imply_left(Rc::new(|x| x(True))))
-}
-
 /// `(a == b) ⋀ theory(a == b)  =>  (a ~~ b)`.
 ///
 /// Lift equality with tautological distinction into quality.

--- a/src/path_semantics/pord.rs
+++ b/src/path_semantics/pord.rs
@@ -34,18 +34,13 @@ impl<T, U> POrdProof<T, U> {
     }
 
     /// Transform left argument by equivalence.
-    pub fn by_eq_left<V>(self, eq: Eq<T, V>) -> POrdProof<V, U> {
-        self.by_imply_left(eq.1)
+    pub fn by_eq_left<V>(self, _: Eq<T, V>) -> POrdProof<V, U> {
+        POrdProof(std::marker::PhantomData)
     }
 
     /// Transform right argument by equivalence.
     pub fn by_eq_right<V>(self, eq: Eq<U, V>) -> POrdProof<T, V> {
         self.by_imply_right(eq.0)
-    }
-
-    /// Transform left argument by implication.
-    pub fn by_imply_left<V>(self, _: Imply<V, T>) -> POrdProof<V, U> {
-        POrdProof(std::marker::PhantomData)
     }
 
     /// Transform right argument by implication.

--- a/src/path_semantics/ty.rs
+++ b/src/path_semantics/ty.rs
@@ -33,11 +33,6 @@ pub fn ty_eq_right<A: Prop, B: Prop, C: Prop>(x: Eq<B, C>) -> Eq<Ty<A, B>, Ty<A,
      Rc::new(move |ty_a| ty_in_right_arg(ty_a, x2.clone())))
 }
 
-/// `(a : b) ⋀ (c => a)  =>  (c : b)`
-pub fn ty_imply_left<A: Prop, B: Prop, C: Prop>(x: Ty<A, B>, y: Imply<C, A>) -> Ty<C, B> {
-    (imply::transitivity(y.clone(), x.0), x.1.by_imply_left(y))
-}
-
 /// `(a : b) ⋀ (b => c)  =>  (a : c)`.
 pub fn ty_imply_right<A: Prop, B: Prop, C: Prop>(x: Ty<A, B>, y: Imply<B, C>) -> Ty<A, C> {
     (imply::transitivity(x.0, y.clone()), x.1.by_imply_right(y))
@@ -69,22 +64,6 @@ pub fn ty_non_triv<X: Prop, A: Prop>(
     ty_in_right_arg(ty_x_a, eq_a_false)
 }
 
-/// `(true : x)  =>  (a : x)`.
-pub fn ty_inhabit<A: Prop, X: Prop>(tr_x: Ty<True, X>) -> Ty<A, X> {
-    (imply::transitivity(True.map_any(), tr_x.0), tr_x.1.by_imply_left(True.map_any()))
-}
-
-/// `((a : b) : x)  =>  (b : x)`.
-pub fn ty_instance<A: Prop, B: Prop, X: Prop>((ab_x, pord_ab_x): Ty<Ty<A, B>, X>) -> Ty<B, X> {
-    (Rc::new(move |b| ab_x(ty_inhabit(ty_rev_true(b)))),
-     pord_ab_x.by_imply_left(Rc::new(move |b| ty_inhabit(ty_rev_true(b)))))
-}
-
-/// `((a : b) : x)  =>  (a : (b : x))`.
-pub fn ty_assoc_right<A: Prop, B: Prop, X: Prop>(x: Ty<Ty<A, B>, X>) -> Ty<A, Ty<B, X>> {
-    ty_inhabit(ty_rev_true(ty_instance(x)))
-}
-
 /// `true == ltrue`.
 pub fn eq_true_ltrue<N: Nat>() -> Eq<True, LTrue<N>> {
     (LTrue(Default::default()).map_any(), True.map_any())
@@ -95,9 +74,6 @@ pub fn ty_true_true() -> Ty<True, True> {
     let x = ty_in_left_arg(ty_ltrue(), eq::symmetry(eq_true_ltrue::<Z>()));
     ty_in_right_arg(x, eq::symmetry(eq_true_ltrue::<S<Z>>()))
 }
-
-/// `a : true`.
-pub fn ty_tr<A: Prop>() -> Ty<A, True> {ty_imply_left(ty_true_true(), True.map_any())}
 
 /// `(x : a) ⋀ (y : b)  =>  ((x ⋀ y) : (a ⋀ b))`.
 pub fn ty_and<X: Prop, Y: Prop, A: Prop, B: Prop>(


### PR DESCRIPTION
Fixes https://github.com/advancedresearch/prop/issues/1487

- Removed `fun::app_swap_tauto_ty`
- Removed `hooo::tauto_ty`
- Removed `ty_imply_left`
- Removed `ty_inhabit`
- Removed `ty_instance`
- Removed `ty_assoc_right`
- Removed `ty_tr`